### PR TITLE
Workaround for AAMP->YAML without names from reader

### DIFF
--- a/aamp/yaml_util.py
+++ b/aamp/yaml_util.py
@@ -50,6 +50,8 @@ def _test_possible_numbered_names(idx: int, wanted_hash: int) -> str:
     return ''
 
 def _get_pstruct_name(reader, idx: int, k: int, parent_crc32: int) -> typing.Union[int, str]:
+    if reader is None:
+        return k
     name = reader._crc32_to_string_map.get(k, None)
     if name is not None:
         return name
@@ -136,7 +138,9 @@ def construct_obj(d: dict) -> ParameterObject:
     pobj.params = {_parse_yaml_dict_key(k): v for k, v in d.items()}
     return pobj
 
-def register_representers(dumper) -> None:
+def register_representers(dumper, no_param_names: bool = False) -> None:
+    if no_param_names:
+        setattr(dumper, '__aamp_reader', None)
     yaml.add_representer(float, represent_float, Dumper=dumper)
     yaml.add_representer(dict, represent_dict, Dumper=dumper)
     yaml.add_representer(ParameterIO, represent_param_io, Dumper=dumper)


### PR DESCRIPTION
This is just a simple workaround to permit dumping AAMP to YAML when there is no reader involved and no parameter names are necessary.