### PR TITLE
Use dataclasses for structures

### DIFF
--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -1,6 +1,5 @@
 import abc
 from dataclasses import dataclass
-import operator
 from enum import IntEnum
 import typing
 import zlib

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -136,9 +136,6 @@ class Curve:
     __slots__ = ['v']
     v: list = field(default_factory=list)
 
-    def __init__(self, v: list = None):
-        self.v = v or []
-
 def value_to_bytes(v: typing.Any) -> typing.Tuple[ParameterType, bytes]:
     if isinstance(v, bool):
         return (ParameterType.Bool, u32(v))

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -80,20 +80,17 @@ class ParameterIO(ParameterList):
 
 @dataclass
 class Vec2:
-    __slots__ = ['x', 'y']
-    x: float = 0.0
+    x: float
     y: float
 
 @dataclass
 class Vec3:
-    __slots__ = ['x', 'y', 'z']
     x: float
     y: float
     z: float
 
 @dataclass
 class Vec4:
-    __slots__ = ['x', 'y', 'z', 'w']
     x: float
     y: float
     z: float
@@ -101,7 +98,6 @@ class Vec4:
 
 @dataclass
 class Color:
-    __slots__ = ['r', 'g', 'b', 'a']
     r: float
     g: float
     b: float
@@ -125,7 +121,6 @@ class U32(int):
 
 @dataclass
 class Quat:
-    __slots__ = ['a', 'b', 'c', 'd']
     a: float
     b: float
     c: float
@@ -133,7 +128,6 @@ class Quat:
 
 @dataclass
 class Curve:
-    __slots__ = ['v']
     v: list = field(default_factory=list)
 
 def value_to_bytes(v: typing.Any) -> typing.Tuple[ParameterType, bytes]:

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -81,20 +81,20 @@ class ParameterIO(ParameterList):
 
 @dataclass
 class Vec2:
-    __slots__ = ('x', 'y')
+    __slots__ = ['x', 'y']
     x: float
     y: float
 
 @dataclass
 class Vec3:
-    __slots__ = ('x', 'y', 'z')
+    __slots__ = ['x', 'y', 'z']
     x: float
     y: float
     z: float
 
 @dataclass
 class Vec4:
-    __slots__ = ('x', 'y', 'z', 'w')
+    __slots__ = ['x', 'y', 'z', 'w']
     x: float
     y: float
     z: float
@@ -102,7 +102,7 @@ class Vec4:
 
 @dataclass
 class Color:
-    __slots__ = ('r', 'g', 'b', 'a')
+    __slots__ = ['r', 'g', 'b', 'a']
     r: float
     g: float
     b: float
@@ -126,7 +126,7 @@ class U32(int):
 
 @dataclass
 class Quat:
-    __slots__ = ('a', 'b', 'c', 'd')
+    __slots__ = ['a', 'b', 'c', 'd']
     a: float
     b: float
     c: float
@@ -134,8 +134,11 @@ class Quat:
 
 @dataclass
 class Curve:
-    __slots__ = ('v')
+    __slots__ = ['v']
     v: list
+
+    def __init__(self, v: list = None):
+        self.v = v or []
 
 def value_to_bytes(v: typing.Any) -> typing.Tuple[ParameterType, bytes]:
     if isinstance(v, bool):

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -82,7 +82,7 @@ class ParameterIO(ParameterList):
 @dataclass
 class Vec2:
     __slots__ = ['x', 'y']
-    x: float
+    x: float = 0.0
     y: float
 
 @dataclass

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -134,7 +134,7 @@ class Quat:
 @dataclass
 class Curve:
     __slots__ = ['v']
-    v: list
+    v: list = field(default_factory=list)
 
     def __init__(self, v: list = None):
         self.v = v or []

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -1,4 +1,5 @@
 import abc
+from dataclasses import dataclass
 import operator
 from enum import IntEnum
 import typing
@@ -78,74 +79,34 @@ class ParameterIO(ParameterList):
     def __repr__(self) -> str:
         return f'ParameterIO(type_={self.type}, version={self.version}, lists={repr(self.lists)})'
 
+@dataclass
 class Vec2:
-    __slots__ = ['x', 'y']
-    def __init__(self, x=0.0, y=0.0) -> None:
-        self.x = x
-        self.y = y
-    def __repr__(self) -> str:
-        return f'Vec2(x={self.x}, y={self.y})'
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
-                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-                 return all(getter(self) == getter(other) for getter in attr_getters)
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    __slots__ = ('x', 'y')
+    x: float
+    y: float
 
+@dataclass
 class Vec3:
-    __slots__ = ['x', 'y', 'z']
-    def __init__(self, x=0.0, y=0.0, z=0.0) -> None:
-        self.x = x
-        self.y = y
-        self.z = z
-    def __repr__(self) -> str:
-        return f'Vec3(x={self.x}, y={self.y}, z={self.z})'
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
-                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-                 return all(getter(self) == getter(other) for getter in attr_getters)
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    __slots__ = ('x', 'y', 'z')
+    x: float
+    y: float
+    z: float
 
+@dataclass
 class Vec4:
-    __slots__ = ['x', 'y', 'z', 'w']
-    def __init__(self, x=0.0, y=0.0, z=0.0, w=0.0) -> None:
-        self.x = x
-        self.y = y
-        self.z = z
-        self.w = w
-    def __repr__(self) -> str:
-        return f'Vec4(x={self.x}, y={self.y}, z={self.z}, w={self.w})'
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
-                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-                 return all(getter(self) == getter(other) for getter in attr_getters)
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    __slots__ = ('x', 'y', 'z', 'w')
+    x: float
+    y: float
+    z: float
+    w: float
 
+@dataclass
 class Color:
-    __slots__ = ['r', 'g', 'b', 'a']
-    def __init__(self, r=0.0, g=0.0, b=0.0, a=0.0) -> None:
-        self.r = r
-        self.g = g
-        self.b = b
-        self.a = a
-    def __repr__(self) -> str:
-        return f'Color(r={self.r}, g={self.g}, b={self.b}, a={self.a})'
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
-                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-                 return all(getter(self) == getter(other) for getter in attr_getters)
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    __slots__ = ('r', 'g', 'b', 'a')
+    r: float
+    g: float
+    b: float
+    a: float
 
 class String32(str):
     def __repr__(self) -> str:
@@ -163,35 +124,18 @@ class U32(int):
     def __repr__(self) -> str:
         return f'U32({self})'
 
+@dataclass
 class Quat:
-    __slots__ = ['a', 'b', 'c', 'd']
-    def __init__(self, a=0.0, b=0.0, c=0.0, d=0.0) -> None:
-        self.a = a
-        self.b = b
-        self.c = c
-        self.d = d
+    __slots__ = ('a', 'b', 'c', 'd')
+    a: float
+    b: float
+    c: float
+    d: float
 
-    def __repr__(self) -> str:
-        return f'Quat({self.a},{self.b},{self.c},{self.d})'
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            if self.__slots__ == other.__slots__:
-                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
-                 return all(getter(self) == getter(other) for getter in attr_getters)
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
-
+@dataclass
 class Curve:
-    __slots__ = ['v']
-    def __init__(self, v=None) -> None:
-        self.v = v if v else []
-    def __eq__(self, other):
-        if isinstance(other, self.__class__):
-            return self.v == other.v
-        return False
-    def __ne__(self, other):
-        return not self.__eq__(other)
+    __slots__ = ('v')
+    v: list
 
 def value_to_bytes(v: typing.Any) -> typing.Tuple[ParameterType, bytes]:
     if isinstance(v, bool):

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -1,5 +1,5 @@
 import abc
-from dataclasses import dataclass
+from dataclasses import dataclass, field
 from enum import IntEnum
 import typing
 import zlib

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -1,4 +1,5 @@
 import abc
+import operator
 from enum import IntEnum
 import typing
 import zlib
@@ -84,6 +85,14 @@ class Vec2:
         self.y = y
     def __repr__(self) -> str:
         return f'Vec2(x={self.x}, y={self.y})'
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if self.__slots__ == other.__slots__:
+                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
+                 return all(getter(self) == getter(other) for getter in attr_getters)
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class Vec3:
     __slots__ = ['x', 'y', 'z']
@@ -93,6 +102,14 @@ class Vec3:
         self.z = z
     def __repr__(self) -> str:
         return f'Vec3(x={self.x}, y={self.y}, z={self.z})'
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if self.__slots__ == other.__slots__:
+                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
+                 return all(getter(self) == getter(other) for getter in attr_getters)
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class Vec4:
     __slots__ = ['x', 'y', 'z', 'w']
@@ -103,6 +120,14 @@ class Vec4:
         self.w = w
     def __repr__(self) -> str:
         return f'Vec4(x={self.x}, y={self.y}, z={self.z}, w={self.w})'
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if self.__slots__ == other.__slots__:
+                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
+                 return all(getter(self) == getter(other) for getter in attr_getters)
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class Color:
     __slots__ = ['r', 'g', 'b', 'a']
@@ -113,6 +138,14 @@ class Color:
         self.a = a
     def __repr__(self) -> str:
         return f'Color(r={self.r}, g={self.g}, b={self.b}, a={self.a})'
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if self.__slots__ == other.__slots__:
+                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
+                 return all(getter(self) == getter(other) for getter in attr_getters)
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class String32(str):
     def __repr__(self) -> str:
@@ -140,11 +173,25 @@ class Quat:
 
     def __repr__(self) -> str:
         return f'Quat({self.a},{self.b},{self.c},{self.d})'
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            if self.__slots__ == other.__slots__:
+                 attr_getters = [operator.attrgetter(attr) for attr in self.__slots__]
+                 return all(getter(self) == getter(other) for getter in attr_getters)
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 class Curve:
     __slots__ = ['v']
     def __init__(self, v=None) -> None:
         self.v = v if v else []
+    def __eq__(self, other):
+        if isinstance(other, self.__class__):
+            return self.v == other.v
+        return False
+    def __ne__(self, other):
+        return not self.__eq__(other)
 
 def value_to_bytes(v: typing.Any) -> typing.Tuple[ParameterType, bytes]:
     if isinstance(v, bool):

--- a/aamp/parameters.py
+++ b/aamp/parameters.py
@@ -80,28 +80,28 @@ class ParameterIO(ParameterList):
 
 @dataclass
 class Vec2:
-    x: float
-    y: float
+    x: float = 0.0
+    y: float = 0.0
 
 @dataclass
 class Vec3:
-    x: float
-    y: float
-    z: float
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
 
 @dataclass
 class Vec4:
-    x: float
-    y: float
-    z: float
-    w: float
+    x: float = 0.0
+    y: float = 0.0
+    z: float = 0.0
+    w: float = 0.0
 
 @dataclass
 class Color:
-    r: float
-    g: float
-    b: float
-    a: float
+    r: float = 0.0
+    g: float = 0.0
+    b: float = 0.0
+    a: float = 0.0
 
 class String32(str):
     def __repr__(self) -> str:
@@ -121,10 +121,10 @@ class U32(int):
 
 @dataclass
 class Quat:
-    a: float
-    b: float
-    c: float
-    d: float
+    a: float = 0.0
+    b: float = 0.0
+    c: float = 0.0
+    d: float = 0.0
 
 @dataclass
 class Curve:

--- a/aamp/yaml_util.py
+++ b/aamp/yaml_util.py
@@ -38,7 +38,7 @@ def represent_dict(dumper, mapping, flow_style=None):
     return represent_mapping(dumper, 'tag:yaml.org,2002:map', mapping, flow_style)
 
 def _fields(data) -> list:
-    return [getattr(data, x) for x in data.__slots__]
+    return list(data.__dict__.values())
 
 @functools.lru_cache(maxsize=None)
 def _test_possible_numbered_names(idx: int, wanted_hash: int) -> str:

--- a/setup.py
+++ b/setup.py
@@ -24,7 +24,10 @@ setuptools.setup(
     ],
     include_package_data=True,
     python_requires='>=3.6',
-    install_requires=['PyYAML~=5.1'],
+    install_requires=[
+        'PyYAML~=5.1',
+        'dataclasses;python_version=="3.6"'
+    ],
     entry_points = {
         'console_scripts': [
             'aamp = aamp.__main__:main',

--- a/setup.py
+++ b/setup.py
@@ -26,7 +26,7 @@ setuptools.setup(
     python_requires='>=3.6',
     install_requires=[
         'PyYAML~=5.1',
-        'dataclasses;python_version=="3.6"'
+        'dataclasses;python_version=="3.6"',
     ],
     entry_points = {
         'console_scripts': [


### PR DESCRIPTION
I found with BCML doing deep merge that checking equivalence between certain parameter types doesn't produce expected results (e.g. `Vec3(0.0, 0.0, 0.0) == Vec3(0.0, 0.0, 0.0)` is false). So I overrode `__eq__` (and `__ne__`) for the relevant parameter types.